### PR TITLE
Add Forth plugin for VSCode to repo recomendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "fttx.language-forth"
+    ]
+}


### PR DESCRIPTION
That's only suggest installing this extension for VS code users.